### PR TITLE
Fix Help dialog closing

### DIFF
--- a/src/ui.coffee
+++ b/src/ui.coffee
@@ -185,7 +185,7 @@ showModal = (div, after) ->
         e.preventDefault()
 
     dismiss = (args...) ->
-        window.removeEventListener('keydown')
+        window.removeEventListener('keydown', onKey)
         div.remove()
         after(args...) if after
 


### PR DESCRIPTION
Fixes error:
funhouse-min.js:formatted:2265 Uncaught TypeError: Failed to execute 'removeEventListener' on 'EventTarget': 2 arguments required, but only 1 present.